### PR TITLE
small changes for shiny server deployment

### DIFF
--- a/server.r
+++ b/server.r
@@ -1,15 +1,17 @@
-library(here)
 library(tensorflow)
 library(keras)
 
-setwd(here())
 # paramNames <- c("start_capital", "annual_mean_return", "annual_ret_std_dev",
 #                 "annual_inflation", "annual_inf_std_dev", "monthly_withdrawals", "n_obs",
 #                 "n_sim")
 
 #use_virtualenv("G:\\tensorflow\\venv")
 #setwd("G:\\tensorflow\\modelProtocolBuffers")
-new_model <- load_model_tf('no_gap')
+
+#needed to set virtual environment on server for shiny user
+use_virtualenv("/home/natalie/.virtualenvs/r-tensorflow")
+
+new_model <- load_model_tf('modelProtocolBuffers/no_gap')
 
 nmc <- compile(new_model)
 ycolnames <- c("fzd", "flength", "ros")


### PR DESCRIPTION
I have to use a venv for the shiny deployment. I also have a slightly different path for the `no_gap` folder (this lives in the shiny app directory). This PR contains the changes I implemented to get it running on the server. There are just a couple of edits. You can merge  this PR if you want, otherwise I'll have to manually make these edits each time we do an update. If you do merge this PR, you can just comment out the `use_virtualenv` line for the shiny deployment. 